### PR TITLE
feat: allow app name as CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@
 
 ## Features
 
+- **CLI Argument for Project Name** — skip the project name prompt by passing the app name as a CLI argument.
 - **Package Manager Detection** — automatically detects installed package managers (`npm`, `yarn`, `pnpm`) and only prompts with available options.
 - **Next.js App Directory** — support for the new Next.js app directory.
 - **Custom Page Generation** — create multiple pages at once.
 - **Linter Support** — choose between no linter, ESLint, and Biome.
-- **Shadcn UI** — automatically install and configure Shadcn UI.
+- **Shadcn UI** — automatically installs and configures Shadcn UI with a default style and color.
 - **Clean Project Setup** — removes default favicon and clears public folder.
 - **Empty Default Page** — overwrites the default `page.tsx` or `index.tsx` with an empty template.
 - **Dynamic Metadata** — always overwrites the `layout.tsx` or `layout.jsx` with a minimal template.
 - **Conditional API Route Deletion** — deletes the default `api/hello.js` route if using the `src` directory and not the `app` directory.
-- **Flexible Project Naming** — allows using `.` to create the project in the current directory.
+- **Safe Project Creation** — checks if the current directory is empty when creating a project in the current directory (`.`) and prevents accidental overwrites.
 - **ORM Support** — choose between no ORM, Prisma, and Drizzle.
 
 ## Installation
@@ -30,7 +31,23 @@ npx create-next-quick
 
 ## 🛠 Usage
 
-When you run `npx create-next-quick`, you will be prompted to:
+You can run `npx create-next-quick` with or without a project name.
+
+### With a Project Name
+
+```bash
+npx create-next-quick my-app
+```
+
+This will skip the project name prompt and create a new directory named `my-app`.
+
+### Without a Project Name
+
+```bash
+npx create-next-quick
+```
+
+When you run `npx create-next-quick` without a project name, you will be prompted to:
 
 1. **Enter Project Name** — e.g., `my-app` (or `.` to create in the current directory). If you use `.` the directory must be empty.
 2. **Choose a package manager** — detects installed package managers (`npm`, `yarn`, `pnpm`) and prompts you to choose.
@@ -40,7 +57,6 @@ When you run `npx create-next-quick`, you will be prompted to:
 6. **Enter the names of the pages you want to create (default: none)**
 7. **Choose a linter (default: none)**
 8. **Choose an ORM (default: none)**
-9. **Choose to use Shadcn UI (default: No)**
 
 Example run:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Features
 
-- **Interactive Setup** — prompts you for project name, TypeScript, Tailwind CSS, and more.
+- **Package Manager Detection** — automatically detects installed package managers (`npm`, `yarn`, `pnpm`) and only prompts with available options.
 - **Next.js App Directory** — support for the new Next.js app directory.
 - **Custom Page Generation** — create multiple pages at once.
 - **Linter Support** — choose between no linter, ESLint, and Biome.
@@ -33,7 +33,7 @@ npx create-next-quick
 When you run `npx create-next-quick`, you will be prompted to:
 
 1. **Enter Project Name** — e.g., `my-app` (or `.` to create in the current directory)
-2. **Choose a package manager (default: pnpm)**
+2. **Choose a package manager** — detects installed package managers (`npm`, `yarn`, `pnpm`) and prompts you to choose.
 3. **Choose to use TypeScript (default: Yes)**
 4. **Choose to use Tailwind CSS (default: Yes)**
 5. **Choose to use the app directory (default: Yes)**

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npx create-next-quick
 
 When you run `npx create-next-quick`, you will be prompted to:
 
-1. **Enter Project Name** — e.g., `my-app` (or `.` to create in the current directory)
+1. **Enter Project Name** — e.g., `my-app` (or `.` to create in the current directory). If you use `.` the directory must be empty.
 2. **Choose a package manager** — detects installed package managers (`npm`, `yarn`, `pnpm`) and prompts you to choose.
 3. **Choose to use TypeScript (default: Yes)**
 4. **Choose to use Tailwind CSS (default: Yes)**

--- a/index.js
+++ b/index.js
@@ -5,6 +5,17 @@ import { run, deleteFolder, createFolder, deleteFile, fileExists, writeFile } fr
 import { createPages, createLayout } from './lib/templates.js';
 
 (async () => {
+    const availablePackageManagers = ["npm"];
+    try {
+        run("yarn --version", process.cwd(), true);
+        availablePackageManagers.push("yarn");
+    } catch (error) { }
+
+    try {
+        run("pnpm --version", process.cwd(), true);
+        availablePackageManagers.push("pnpm");
+    } catch (error) { }
+
     const answers = await inquirer.prompt([
         {
             type: "input",
@@ -22,7 +33,7 @@ import { createPages, createLayout } from './lib/templates.js';
             type: "list",
             name: "packageManager",
             message: "Choose a package manager:",
-            choices: ["npm", "yarn", "pnpm"],
+            choices: availablePackageManagers,
             default: "pnpm"
         },
         {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import inquirer from "inquirer";
 import path from "path";
+import fs from "fs";
 import { run, deleteFolder, createFolder, deleteFile, fileExists, writeFile } from './lib/utils.js';
 import { createPages, createLayout } from './lib/templates.js';
 
@@ -25,6 +26,12 @@ import { createPages, createLayout } from './lib/templates.js';
             validate: (input) => {
                 if (input !== input.toLowerCase()) {
                     return "Project name must be in lowercase.";
+                }
+                if (input === ".") {
+                    const files = fs.readdirSync(process.cwd());
+                    if (files.length > 0) {
+                        return "The current directory is not empty. Please use a different project name.";
+                    }
                 }
                 return true;
             }

--- a/index.js
+++ b/index.js
@@ -17,25 +17,49 @@ import { createPages, createLayout } from './lib/templates.js';
         availablePackageManagers.push("pnpm");
     } catch (error) { }
 
-    const answers = await inquirer.prompt([
-        {
-            type: "input",
-            name: "projectName",
-            message: "Enter project name:",
-            filter: (input) => input.trim() === '' ? '.' : input.trim(),
-            validate: (input) => {
-                if (input !== input.toLowerCase()) {
-                    return "Project name must be in lowercase.";
-                }
-                if (input === ".") {
-                    const files = fs.readdirSync(process.cwd());
-                    if (files.length > 0) {
-                        return "The current directory is not empty. Please use a different project name.";
-                    }
-                }
-                return true;
+    const validateProjectName = (input) => {
+        if (input !== input.toLowerCase()) {
+            return "Project name must be in lowercase.";
+        }
+        if (input === ".") {
+            const files = fs.readdirSync(process.cwd());
+            if (files.length > 0) {
+                return "The current directory is not empty. Please use a different project name.";
             }
-        },
+        } else {
+            if (fs.existsSync(input)) {
+                return `A directory named "${input}" already exists. Please use a different project name.`;
+            }
+        }
+        return true;
+    };
+
+    const appName = process.argv[2];
+    const answers = {};
+
+    if (appName) {
+        const validationResult = validateProjectName(appName);
+        if (validationResult !== true) {
+            console.error(validationResult);
+        } else {
+            answers.projectName = appName;
+        }
+    }
+
+    if (!answers.projectName) {
+        const appNameAnswers = await inquirer.prompt([
+            {
+                type: "input",
+                name: "projectName",
+                message: "Enter project name:",
+                filter: (input) => input.trim() === '' ? '.' : input.trim(),
+                validate: validateProjectName
+            }
+        ]);
+        answers.projectName = appNameAnswers.projectName;
+    }
+
+    const otherAnswers = await inquirer.prompt([
         {
             type: "list",
             name: "packageManager",
@@ -95,6 +119,8 @@ import { createPages, createLayout } from './lib/templates.js';
             default: false
         }
     ]);
+
+    Object.assign(answers, otherAnswers);
 
     const { projectName, packageManager, useTypeScript, useTailwind, useAppDir, useSrcDir, pages, linter, orm, useShadcn } = answers;
     const projectPath = path.join(process.cwd(), projectName);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,9 +2,11 @@ import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
 
-export const run = (cmd, cwd = process.cwd()) => {
-    console.log(`\nRunning: ${cmd}`);
-    execSync(cmd, { stdio: "inherit", cwd });
+export const run = (cmd, cwd = process.cwd(), silent = false) => {
+    if (!silent) {
+        console.log(`\nRunning: ${cmd}`);
+    }
+    execSync(cmd, { stdio: silent ? "pipe" : "inherit", cwd });
 };
 
 export const writeFile = (filePath, content) => {


### PR DESCRIPTION
## Description

This commit introduces the ability to pass the app name as a CLI argument, skipping the project name
prompt.

- If a valid app name is provided, the prompt is skipped.
The README has been updated to reflect these changes and other improvements from this session.

## Related Issue
<!-- Please link to the issue here -->
Closes #16 

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change addressing an issue)
- [X] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Documentation update

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes