### PR TITLE
Fixed the github workflow to greate only for the run time contibutor

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Greet on New Issue
         uses: actions/github-script@v7
-        if: github.event_name == 'issues'
+        if: github.event_name == 'issues' && github.event.issue.author_association == 'NONE'
         with:
           script: |
             const body = `👋 Hello @${{ github.actor }}!
@@ -31,7 +31,7 @@ jobs:
 
       - name: Greet on New Pull Request
         uses: actions/github-script@v7
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' && github.event.pull_request.author_association == 'FIRST_TIMER'
         with:
           script: |
             const body = `🎉 Welcome, @${{ github.actor }}!


### PR DESCRIPTION
## Description

The welcome bot was incorrectly triggering for all users on new issues and pull requests. This has been resolved by updating the workflow to only run for first-time contributors. The workflow now checks the `author_association` to ensure that the welcome message is exclusively sent to users making their first contribution to the repository.

## Related Issue

Closes #52 

## Type of Change

- [x] Bug fix (non-breaking change addressing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Documentation update

## Steps to Reproduce

1. Create a new issue or pull request.
2. Previously, the welcome bot ran for all users.
3. After this fix, the bot triggers **only for first-time contributors**.

## Package Version

1.0.6

## System Info

- Platform: GitHub

## Testing

- [x] Verified the bot triggers only for first-time committers.
- [x] Verified existing users creating additional issues/PRs do not trigger the bot.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

- This ensures a cleaner onboarding experience for new contributors.
