### PR TITLE
fix: handle default project name and update test timing and inputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,9 @@ import { createPages, createLayout } from './lib/templates.js';
   Object.assign(answers, otherAnswers);
 
   const { projectName, packageManager, useTypeScript, useTailwind, useAppDir, useSrcDir, pages, linter, orm, useShadcn } = answers;
-  const projectPath = path.join(process.cwd(), projectName);
+  
+  const displayName = projectName === '.' ? path.basename(process.cwd()) : projectName;
+  const projectPath = projectName === '.' ? process.cwd() : path.join(process.cwd(), projectName);
 
   console.log();
   console.log(chalk.bold.hex("#23f0bcff")("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"));
@@ -190,7 +192,7 @@ import { createPages, createLayout } from './lib/templates.js';
 
   console.log(chalk.magenta("Creating layout files..."));
 
-  createLayout(projectPath, projectName, useTypeScript, useAppDir, useSrcDir);
+  createLayout(projectPath, displayName, useTypeScript, useAppDir, useSrcDir);
 
   const pagesPath = useAppDir
     ? (useSrcDir ? path.join(projectPath, "src", "app") : path.join(projectPath, "app"))
@@ -226,7 +228,7 @@ import { createPages, createLayout } from './lib/templates.js';
   writeFile(defaultPagePath, emptyPageContent);
 
   const readmePath = path.join(projectPath, "README.md");
-  writeFile(readmePath, `# ${projectName}`);
+  writeFile(readmePath, `# ${displayName}`);
 
   console.log(chalk.bold.green("Layout and pages created"));
 
@@ -344,7 +346,9 @@ import { createPages, createLayout } from './lib/templates.js';
   console.log(chalk.bold.hex("#23f0bcff")("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"));
   console.log();
   console.log(chalk.bold.white("-> Next steps:"));
-  console.log(chalk.cyan(`  cd ${chalk.bold.white(projectName)}`));
+  if (projectName !== '.') {
+    console.log(chalk.cyan(`  cd ${chalk.bold.white(projectName)}`));
+  }
   console.log(chalk.cyan(`  ${packageManager} ${chalk.bold.white(`run dev`)}`));
   console.log();
   console.log(chalk.white.bold(`Thank you for using create-next-quick!`));

--- a/test/test.js
+++ b/test/test.js
@@ -40,7 +40,7 @@ describe('create-next-quick', function () {
         clearInterval(interval);
         child.stdin.end();
       }
-    }, 1000);
+    }, 3000);
 
     child.on('close', (code) => {
       assert.strictEqual(code, 0, 'CLI should exit with code 0');
@@ -61,7 +61,7 @@ describe('create-next-quick', function () {
         testCase.options.pages + '\n',
         testCase.options.linter + '\n',
         testCase.options.orm + '\n',
-        testCase.options.useShadcn ? 'y\n' : '\n',
+        testCase.options.useShadcn ? '\n' : 'n\n',
       ];
 
       const assertions = () => {


### PR DESCRIPTION
## Description

Added logic to set projectName to current directory name if user inputs '.' to improve usability when naming projects.

Increased test timeout duration from 1000ms to 3000ms to prevent premature test failures.

Corrected test input for useShadcn option by sending '\n' (default yes) when enabled and 'n\n' when disabled, aligning tests with updated CLI prompt behavior.

This commit enhances user experience by better handling project naming edge cases and improves test reliability by adjusting timing and input responses.

## Related Issue

<!-- Please link to the issue here -->

Fixes #58 
Closes #58 

## Type of Change

<!-- Please delete options that are not relevant -->

- [X] Bug fix (non-breaking change addressing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Documentation update