### PR TITLE
[codex] Fix confirm prompt default regression

### DIFF
--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -24,7 +24,8 @@ const processQuestion = async (question) => {
   const hasDefaultSuffix = /\(default:\s*[^)]+\)\s*$/i.test(message);
   const confirmDefault =
     defaultVal === true ||
-    (typeof defaultVal === "string" && defaultVal.trim().toLowerCase() === "true");
+    (typeof defaultVal === "string" &&
+      ["true", "yes", "1"].includes(defaultVal.trim().toLowerCase()));
   const defaultDisplay = type === "confirm" ? (confirmDefault ? "Yes" : "No") : defaultVal;
   const displayMessage = `${message}${defaultVal !== undefined && !hasDefaultSuffix ? ` (default: ${defaultDisplay})` : ""} `;
 

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -21,7 +21,7 @@ const processQuestion = async (question) => {
   let answer;
   const { type, name, message, default: defaultVal, choices, validate, filter } = question;
 
-  const hasDefaultSuffix = /\(default:\s*[^)]+\)/i.test(message);
+  const hasDefaultSuffix = /\(default:\s*[^)]+\)\s*$/i.test(message);
   const defaultDisplay = type === "confirm" ? (defaultVal === true ? "Yes" : "No") : defaultVal;
   const displayMessage = `${message}${defaultVal !== undefined && !hasDefaultSuffix ? ` (default: ${defaultDisplay})` : ""} `;
 

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -21,7 +21,9 @@ const processQuestion = async (question) => {
   let answer;
   const { type, name, message, default: defaultVal, choices, validate, filter } = question;
 
-  const displayMessage = `${message}${defaultVal !== undefined ? ` (default: ${type === "confirm" ? (defaultVal === true ? "Yes" : "No") : defaultVal})` : ""} `;
+  const hasDefaultSuffix = /\(default:\s*[^)]+\)/i.test(message);
+  const defaultDisplay = type === "confirm" ? (defaultVal === true ? "Yes" : "No") : defaultVal;
+  const displayMessage = `${message}${defaultVal !== undefined && !hasDefaultSuffix ? ` (default: ${defaultDisplay})` : ""} `;
 
   const confirmHint = defaultVal === true ? "(Y/n)" : "(y/N)";
   if (type === "confirm") {
@@ -31,7 +33,7 @@ const processQuestion = async (question) => {
       );
       const trimmed = input.trim().toLowerCase();
       if (trimmed === "") {
-        answer = defaultVal !== undefined ? defaultVal : false;
+        answer = defaultVal === true;
         break;
       }
       if (trimmed === "y" || trimmed === "yes") {

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -22,10 +22,13 @@ const processQuestion = async (question) => {
   const { type, name, message, default: defaultVal, choices, validate, filter } = question;
 
   const hasDefaultSuffix = /\(default:\s*[^)]+\)\s*$/i.test(message);
-  const defaultDisplay = type === "confirm" ? (defaultVal === true ? "Yes" : "No") : defaultVal;
+  const confirmDefault =
+    defaultVal === true ||
+    (typeof defaultVal === "string" && defaultVal.trim().toLowerCase() === "true");
+  const defaultDisplay = type === "confirm" ? (confirmDefault ? "Yes" : "No") : defaultVal;
   const displayMessage = `${message}${defaultVal !== undefined && !hasDefaultSuffix ? ` (default: ${defaultDisplay})` : ""} `;
 
-  const confirmHint = defaultVal === true ? "(Y/n)" : "(y/N)";
+  const confirmHint = confirmDefault ? "(Y/n)" : "(y/N)";
   const renderConfirmSelection = (value) => {
     if (!process.stdin.isTTY || !process.stdout.isTTY) return;
     const renderedMessage = displayMessage.trimEnd();
@@ -44,7 +47,7 @@ const processQuestion = async (question) => {
       );
       const trimmed = input.trim().toLowerCase();
       if (trimmed === "") {
-        answer = defaultVal === true;
+        answer = confirmDefault;
         renderConfirmSelection(answer);
         break;
       }

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -49,7 +49,7 @@ const processQuestion = async (question) => {
     const selectedLabel = value ? "Yes" : "No";
     const promptText = `? ${renderedMessage} ${confirmHint} ${input}`;
     const promptRows = getRenderedRowCount(promptText);
-    readline.moveCursor(process.stdout, 0, -(promptRows - 1));
+    readline.moveCursor(process.stdout, 0, -promptRows);
     readline.cursorTo(process.stdout, 0);
     readline.clearScreenDown(process.stdout);
     process.stdout.write(

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -17,6 +17,11 @@ const ask = (query) => {
   return new Promise((resolve) => getRl().question(query, resolve));
 };
 
+const getRenderedRowCount = (text, columns = process.stdout.columns ?? 80) => {
+  const safeColumns = Math.max(columns || 80, 1);
+  return Math.max(1, Math.ceil(text.length / safeColumns));
+};
+
 const processQuestion = async (question) => {
   let answer;
   const { type, name, message, default: defaultVal, choices, validate, filter } = question;
@@ -30,13 +35,15 @@ const processQuestion = async (question) => {
   const displayMessage = `${message}${defaultVal !== undefined && !hasDefaultSuffix ? ` (default: ${defaultDisplay})` : ""} `;
 
   const confirmHint = confirmDefault ? "(Y/n)" : "(y/N)";
-  const renderConfirmSelection = (value) => {
+  const renderConfirmSelection = (value, input = "") => {
     if (!process.stdin.isTTY || !process.stdout.isTTY) return;
     const renderedMessage = displayMessage.trimEnd();
     const selectedLabel = value ? "Yes" : "No";
-    readline.moveCursor(process.stdout, 0, -1);
-    readline.clearLine(process.stdout, 0);
+    const promptText = `? ${displayMessage} ${confirmHint} ${input}`;
+    const promptRows = getRenderedRowCount(promptText);
+    readline.moveCursor(process.stdout, 0, -promptRows);
     readline.cursorTo(process.stdout, 0);
+    readline.clearScreenDown(process.stdout);
     process.stdout.write(
       `${chalk.green("?")} ${chalk.bold(renderedMessage)} ${chalk.cyan(selectedLabel)}\n`,
     );
@@ -49,17 +56,17 @@ const processQuestion = async (question) => {
       const trimmed = input.trim().toLowerCase();
       if (trimmed === "") {
         answer = confirmDefault;
-        renderConfirmSelection(answer);
+        renderConfirmSelection(answer, input);
         break;
       }
       if (trimmed === "y" || trimmed === "yes") {
         answer = true;
-        renderConfirmSelection(answer);
+        renderConfirmSelection(answer, input);
         break;
       }
       if (trimmed === "n" || trimmed === "no") {
         answer = false;
-        renderConfirmSelection(answer);
+        renderConfirmSelection(answer, input);
         break;
       }
     }
@@ -221,4 +228,8 @@ const close = () => {
 export default {
   prompt,
   close,
+};
+
+export const __testing = {
+  getRenderedRowCount,
 };

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -27,7 +27,7 @@ const processQuestion = async (question) => {
   if (type === "confirm") {
     while (true) {
       const input = await ask(
-        `${chalk.green("?")} ${chalk.bold(message)} ${chalk.dim(confirmHint)} `,
+        `${chalk.green("?")} ${chalk.bold(displayMessage)} ${chalk.dim(confirmHint)} `,
       );
       const trimmed = input.trim().toLowerCase();
       if (trimmed === "") {

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -22,6 +22,14 @@ const getRenderedRowCount = (text, columns = process.stdout.columns ?? 80) => {
   return Math.max(1, Math.ceil(text.length / safeColumns));
 };
 
+const resolveConfirmInput = (input, defaultValue) => {
+  const trimmed = input.trim().toLowerCase();
+  if (trimmed === "") return defaultValue;
+  if (trimmed === "y" || trimmed === "yes") return true;
+  if (trimmed === "n" || trimmed === "no") return false;
+  return undefined;
+};
+
 const processQuestion = async (question) => {
   let answer;
   const { type, name, message, default: defaultVal, choices, validate, filter } = question;
@@ -35,41 +43,96 @@ const processQuestion = async (question) => {
   const displayMessage = `${message}${defaultVal !== undefined && !hasDefaultSuffix ? ` (default: ${defaultDisplay})` : ""} `;
 
   const confirmHint = confirmDefault ? "(Y/n)" : "(y/N)";
+  const renderedMessage = displayMessage.trimEnd();
   const renderConfirmSelection = (value, input = "") => {
-    if (!process.stdin.isTTY || !process.stdout.isTTY) return;
-    const renderedMessage = displayMessage.trimEnd();
+    if (!process.stdout.isTTY) return;
     const selectedLabel = value ? "Yes" : "No";
-    const promptText = `? ${displayMessage} ${confirmHint} ${input}`;
+    const promptText = `? ${renderedMessage} ${confirmHint} ${input}`;
     const promptRows = getRenderedRowCount(promptText);
-    readline.moveCursor(process.stdout, 0, -promptRows);
+    readline.moveCursor(process.stdout, 0, -(promptRows - 1));
     readline.cursorTo(process.stdout, 0);
     readline.clearScreenDown(process.stdout);
     process.stdout.write(
       `${chalk.green("?")} ${chalk.bold(renderedMessage)} ${chalk.cyan(selectedLabel)}\n`,
     );
   };
-  if (type === "confirm") {
-    while (true) {
-      const input = await ask(
-        `${chalk.green("?")} ${chalk.bold(displayMessage)} ${chalk.dim(confirmHint)} `,
-      );
-      const trimmed = input.trim().toLowerCase();
-      if (trimmed === "") {
-        answer = confirmDefault;
-        renderConfirmSelection(answer, input);
-        break;
-      }
-      if (trimmed === "y" || trimmed === "yes") {
-        answer = true;
-        renderConfirmSelection(answer, input);
-        break;
-      }
-      if (trimmed === "n" || trimmed === "no") {
-        answer = false;
-        renderConfirmSelection(answer, input);
-        break;
+
+  const askConfirm = async () => {
+    const { stdin, stdout } = process;
+    const confirmPrompt = `${chalk.green("?")} ${chalk.bold(renderedMessage)} ${chalk.dim(confirmHint)} `;
+
+    if (!stdin.isTTY || !stdout.isTTY) {
+      while (true) {
+        const input = await ask(confirmPrompt);
+        const resolved = resolveConfirmInput(input, confirmDefault);
+        if (resolved !== undefined) return resolved;
       }
     }
+
+    return new Promise((resolve) => {
+      let input = "";
+
+      const cleanup = () => {
+        stdin.removeListener("keypress", handleKeypress);
+        stdin.setRawMode(false);
+      };
+
+      const resetPrompt = () => {
+        const promptRows = getRenderedRowCount(`? ${renderedMessage} ${confirmHint} ${input}`);
+        readline.moveCursor(stdout, 0, -(promptRows - 1));
+        readline.cursorTo(stdout, 0);
+        readline.clearScreenDown(stdout);
+        input = "";
+        stdout.write(confirmPrompt);
+      };
+
+      const complete = (value) => {
+        cleanup();
+        renderConfirmSelection(value, input);
+        resolve(value);
+      };
+
+      const handleKeypress = (str, key) => {
+        if (key?.ctrl && key.name === "c") {
+          cleanup();
+          process.exit(0);
+        }
+
+        if (key?.name === "return" || key?.name === "enter") {
+          const resolved = resolveConfirmInput(input, confirmDefault);
+          if (resolved === undefined) {
+            resetPrompt();
+            return;
+          }
+
+          complete(resolved);
+          return;
+        }
+
+        if (key?.name === "backspace") {
+          if (input.length === 0) return;
+          input = input.slice(0, -1);
+          readline.moveCursor(stdout, -1, 0);
+          readline.clearLine(stdout, 1);
+          return;
+        }
+
+        if (str && str >= " " && !key?.ctrl && !key?.meta) {
+          input += str;
+          stdout.write(str);
+        }
+      };
+
+      stdout.write(confirmPrompt);
+      readline.emitKeypressEvents(stdin);
+      stdin.setRawMode(true);
+      stdin.resume();
+      stdin.on("keypress", handleKeypress);
+    });
+  };
+
+  if (type === "confirm") {
+    answer = await askConfirm();
   } else if (type === "list") {
     const { stdin, stdout } = process;
 

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -26,6 +26,17 @@ const processQuestion = async (question) => {
   const displayMessage = `${message}${defaultVal !== undefined && !hasDefaultSuffix ? ` (default: ${defaultDisplay})` : ""} `;
 
   const confirmHint = defaultVal === true ? "(Y/n)" : "(y/N)";
+  const renderConfirmSelection = (value) => {
+    if (!process.stdin.isTTY || !process.stdout.isTTY) return;
+    const renderedMessage = displayMessage.trimEnd();
+    const selectedLabel = value ? "Yes" : "No";
+    readline.moveCursor(process.stdout, 0, -1);
+    readline.clearLine(process.stdout, 0);
+    readline.cursorTo(process.stdout, 0);
+    process.stdout.write(
+      `${chalk.green("?")} ${chalk.bold(renderedMessage)} ${chalk.cyan(selectedLabel)}\n`,
+    );
+  };
   if (type === "confirm") {
     while (true) {
       const input = await ask(
@@ -34,14 +45,17 @@ const processQuestion = async (question) => {
       const trimmed = input.trim().toLowerCase();
       if (trimmed === "") {
         answer = defaultVal === true;
+        renderConfirmSelection(answer);
         break;
       }
       if (trimmed === "y" || trimmed === "yes") {
         answer = true;
+        renderConfirmSelection(answer);
         break;
       }
       if (trimmed === "n" || trimmed === "no") {
         answer = false;
+        renderConfirmSelection(answer);
         break;
       }
     }

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -23,7 +23,7 @@ const processQuestion = async (question) => {
 
   const displayMessage = `${message}${defaultVal !== undefined ? ` (default: ${type === "confirm" ? (defaultVal ? "Yes" : "No") : defaultVal})` : ""} `;
 
-  const confirmHint = defaultVal ? "(Y/n)" : "(y/N)";
+  const confirmHint = defaultVal === true ? "(Y/n)" : "(y/N)";
   if (type === "confirm") {
     while (true) {
       const input = await ask(

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -21,7 +21,7 @@ const processQuestion = async (question) => {
   let answer;
   const { type, name, message, default: defaultVal, choices, validate, filter } = question;
 
-  const displayMessage = `${message}${defaultVal !== undefined ? ` (default: ${type === "confirm" ? (defaultVal ? "Yes" : "No") : defaultVal})` : ""} `;
+  const displayMessage = `${message}${defaultVal !== undefined ? ` (default: ${type === "confirm" ? (defaultVal === true ? "Yes" : "No") : defaultVal})` : ""} `;
 
   const confirmHint = defaultVal === true ? "(Y/n)" : "(y/N)";
   if (type === "confirm") {

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -3,6 +3,7 @@ import { strict as assert } from "node:assert";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import fs from "node:fs";
+import { __testing as promptsTesting } from "../lib/prompts.js";
 import { deleteFolder } from "../lib/utils.js";
 import { testCases } from "./test-cases.js";
 
@@ -72,6 +73,20 @@ const runPromptQuestion = (question, stdinInput = "\n") =>
   });
 
 describe("prompt rendering", () => {
+  it("counts wrapped confirm prompts as multiple terminal rows", () => {
+    assert.strictEqual(
+      promptsTesting.getRenderedRowCount(
+        "? Do you want to use TypeScript? (default: Yes) (Y/n) ",
+        20,
+      ),
+      3,
+    );
+  });
+
+  it("includes typed confirm input in the rendered row count", () => {
+    assert.strictEqual(promptsTesting.getRenderedRowCount("? Example prompt (Y/n) yes", 10), 3);
+  });
+
   it("does not duplicate explicit confirm defaults in the rendered prompt", async () => {
     const { output } = await runPromptQuestion({
       type: "confirm",

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -88,6 +88,21 @@ describe("prompt rendering", () => {
     assert.match(output, /\(Y\/n\)/);
   });
 
+  it("adds a default suffix when the token appears mid-message", async () => {
+    const { output } = await runPromptQuestion({
+      type: "confirm",
+      name: "useTypeScript",
+      message: "Use (default: Yes) as an example",
+      default: true,
+    });
+
+    assert.strictEqual(
+      (output.match(/\(default: Yes\)/g) || []).length,
+      2,
+      `Expected the default label to be appended at the end.\n${output}`,
+    );
+  });
+
   it("normalizes empty confirm answers to a boolean", async () => {
     const { result } = await runPromptQuestion({
       type: "confirm",

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -9,6 +9,97 @@ import { testCases } from "./test-cases.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const cliPath = path.join(__dirname, "..", "..", "dist", "create-next-quick.js");
+const repoRoot = path.join(__dirname, "..", "..");
+const ansiPattern = new RegExp(`${String.fromCharCode(27)}\\[[0-9;?]*[ -/]*[@-~]`, "g");
+
+const stripAnsi = (value) => value.replace(ansiPattern, "");
+
+const runPromptQuestion = (question, stdinInput = "\n") =>
+  new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+          import prompts from "./src/lib/prompts.js";
+          const result = await prompts.prompt([${JSON.stringify(question)}]);
+          prompts.close();
+          console.log("RESULT=" + JSON.stringify(result));
+        `,
+      ],
+      { cwd: repoRoot },
+    );
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    child.on("error", reject);
+
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `Prompt runner exited with code ${code}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+          ),
+        );
+        return;
+      }
+
+      const cleanOutput = stripAnsi(stdout);
+      const resultMatch = cleanOutput.match(/RESULT=(\{.*\})/s);
+
+      if (!resultMatch) {
+        reject(new Error(`Prompt runner did not emit result.\nstdout:\n${cleanOutput}`));
+        return;
+      }
+
+      resolve({
+        output: cleanOutput,
+        result: JSON.parse(resultMatch[1]),
+      });
+    });
+
+    child.stdin.end(stdinInput);
+  });
+
+describe("prompt rendering", () => {
+  it("does not duplicate explicit confirm defaults in the rendered prompt", async () => {
+    const { output } = await runPromptQuestion({
+      type: "confirm",
+      name: "useTypeScript",
+      message: "Do you want to use TypeScript? (default: Yes)",
+      default: true,
+    });
+
+    assert.strictEqual(
+      (output.match(/\(default: Yes\)/g) || []).length,
+      1,
+      `Expected a single default label in prompt output.\n${output}`,
+    );
+    assert.match(output, /\(Y\/n\)/);
+  });
+
+  it("normalizes empty confirm answers to a boolean", async () => {
+    const { result } = await runPromptQuestion({
+      type: "confirm",
+      name: "docker",
+      message: "Do you want to add Docker support?",
+      default: "false",
+    });
+
+    assert.strictEqual(result.docker, false);
+    assert.strictEqual(typeof result.docker, "boolean");
+  });
+});
 
 describe("create-next-quick", function () {
   this.timeout(0);

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -24,12 +24,16 @@ const runPromptQuestion = (question, stdinInput = "\n") =>
         "-e",
         `
           import prompts from "./src/lib/prompts.js";
-          const result = await prompts.prompt([${JSON.stringify(question)}]);
+          const question = JSON.parse(process.env.PROMPT_QUESTION);
+          const result = await prompts.prompt([question]);
           prompts.close();
           console.log("RESULT=" + JSON.stringify(result));
         `,
       ],
-      { cwd: repoRoot },
+      {
+        cwd: repoRoot,
+        env: { ...process.env, PROMPT_QUESTION: JSON.stringify(question) },
+      },
     );
 
     let stdout = "";
@@ -116,6 +120,17 @@ describe("prompt rendering", () => {
       2,
       `Expected the default label to be appended at the end.\n${output}`,
     );
+  });
+
+  it("supports template-literal characters in question content", async () => {
+    const { output } = await runPromptQuestion({
+      type: "confirm",
+      name: "useExample",
+      message: "Use `code` and ${value} literally?",
+      default: true,
+    });
+
+    assert.match(output, /Use `code` and \$\{value\} literally\?/);
   });
 
   it("normalizes empty confirm answers to a boolean", async () => {

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -114,6 +114,18 @@ describe("prompt rendering", () => {
     assert.strictEqual(result.docker, false);
     assert.strictEqual(typeof result.docker, "boolean");
   });
+
+  it("treats string true defaults as true", async () => {
+    const { result } = await runPromptQuestion({
+      type: "confirm",
+      name: "docker",
+      message: "Do you want to add Docker support?",
+      default: "true",
+    });
+
+    assert.strictEqual(result.docker, true);
+    assert.strictEqual(typeof result.docker, "boolean");
+  });
 });
 
 describe("create-next-quick", function () {

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -24,16 +24,14 @@ const runPromptQuestion = (question, stdinInput = "\n") =>
         "-e",
         `
           import prompts from "./src/lib/prompts.js";
-          const question = JSON.parse(process.env.PROMPT_QUESTION);
+          const question = JSON.parse(process.argv[1]);
           const result = await prompts.prompt([question]);
           prompts.close();
           console.log("RESULT=" + JSON.stringify(result));
         `,
+        JSON.stringify(question),
       ],
-      {
-        cwd: repoRoot,
-        env: { ...process.env, PROMPT_QUESTION: JSON.stringify(question) },
-      },
+      { cwd: repoRoot },
     );
 
     let stdout = "";
@@ -105,6 +103,7 @@ describe("prompt rendering", () => {
       `Expected a single default label in prompt output.\n${output}`,
     );
     assert.match(output, /\(Y\/n\)/);
+    assert.doesNotMatch(output, /\(default: Yes\)\s{2}\(Y\/n\)/);
   });
 
   it("adds a default suffix when the token appears mid-message", async () => {
@@ -126,7 +125,7 @@ describe("prompt rendering", () => {
     const { output } = await runPromptQuestion({
       type: "confirm",
       name: "useExample",
-      message: "Use `code` and ${value} literally?",
+      message: "Use `code` and $" + "{value} literally?",
       default: true,
     });
 

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -55,16 +55,16 @@ const runPromptQuestion = (question, stdinInput = "\n") =>
       }
 
       const cleanOutput = stripAnsi(stdout);
-      const resultMatch = cleanOutput.match(/RESULT=(\{.*\})/s);
+      const resultLine = cleanOutput.split(/\r?\n/).find((line) => line.includes("RESULT="));
 
-      if (!resultMatch) {
+      if (!resultLine) {
         reject(new Error(`Prompt runner did not emit result.\nstdout:\n${cleanOutput}`));
         return;
       }
 
       resolve({
         output: cleanOutput,
-        result: JSON.parse(resultMatch[1]),
+        result: JSON.parse(resultLine.slice(resultLine.indexOf("RESULT=") + "RESULT=".length)),
       });
     });
 


### PR DESCRIPTION
## Summary
- avoid duplicating `(default: ...)` in confirm prompts when the message already includes a default suffix
- normalize empty confirm answers to a boolean instead of returning raw string defaults
- add regression coverage for both prompt behaviors

## Root Cause
The previous fix switched confirm rendering from `message` to `displayMessage`, but some callers already embed `(default: Yes)` in the prompt text. That caused duplicated default text in the rendered confirm line. The confirm handler also returned the raw `default` value on empty input, which could leak string defaults instead of a boolean.

## Validation
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm exec biome check src/lib/prompts.js src/test/test.js`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoid duplicate "(default: ...)" annotations in confirmation prompts.
  * Compute confirmation default using broader true-like checks (e.g., "true", "yes", "1") and display as Yes/No; empty submit now resolves to the boolean default.
  * Update displayed (Y/n)/(y/N) hint and redraw selected Yes/No on interactive terminals for clearer feedback.

* **Tests**
  * Added tests validating confirm prompt rendering, default annotation behavior, and boolean normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after the minor double-space cosmetic fix; no functional or security regressions.

All three previously flagged concerns (cursor-up row count, truthy-string normalization, JSON interpolation in tests) are now addressed. The remaining double-space issue in the rendered confirm prompt is cosmetic and does not affect correctness or the user's ability to answer the question.

src/lib/prompts.js line 54 — double space before (Y/n) hint
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22gaureshpai%2Fcreate-next-quick%22%20on%20the%20existing%20branch%20%22codex%2Ffix-confirm-prompt-defaults%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-confirm-prompt-defaults%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fprompts.js%3A54%0A**Double%20space%20before%20confirm%20hint**%0A%0A%60displayMessage%60%20is%20constructed%20with%20a%20trailing%20space%20on%20line%2035%20%28the%20template%20literal%20ends%20with%20%60%7D%20%22%60%29.%20When%20this%20is%20interpolated%20into%20the%20%60ask%60%20call%20with%20%60%60%20%60%24%7Bchalk.bold%28displayMessage%29%7D%20%24%7Bchalk.dim%28confirmHint%29%7D%20%60%20%60%60%2C%20the%20trailing%20space%20from%20%60displayMessage%60%20and%20the%20leading%20space%20from%20the%20template%20combine%20to%20produce%20two%20spaces%20between%20the%20message%20and%20the%20hint%3A%0A%0A%60%60%60%0A%3F%20Do%20you%20want%20to%20use%20TypeScript%3F%20%28default%3A%20Yes%29%20%20%28Y%2Fn%29%0A%60%60%60%0A%0ABefore%20this%20PR%20the%20raw%20%60message%60%20%28no%20trailing%20space%29%20was%20used%20here%2C%20so%20only%20one%20space%20appeared.%20Consider%20trimming%20%60displayMessage%60%20at%20the%20point%20of%20use%20%E2%80%94%20the%20same%20%60renderedMessage%60%20alias%20used%20inside%20%60renderConfirmSelection%60%20would%20work%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%60%24%7Bchalk.green%28%22%3F%22%29%7D%20%24%7Bchalk.bold%28displayMessage.trimEnd%28%29%29%7D%20%24%7Bchalk.dim%28confirmHint%29%7D%20%60%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fprompts.js%3A54%0A**Double%20space%20before%20confirm%20hint**%0A%0A%60displayMessage%60%20is%20constructed%20with%20a%20trailing%20space%20on%20line%2035%20%28the%20template%20literal%20ends%20with%20%60%7D%20%22%60%29.%20When%20this%20is%20interpolated%20into%20the%20%60ask%60%20call%20with%20%60%60%20%60%24%7Bchalk.bold%28displayMessage%29%7D%20%24%7Bchalk.dim%28confirmHint%29%7D%20%60%20%60%60%2C%20the%20trailing%20space%20from%20%60displayMessage%60%20and%20the%20leading%20space%20from%20the%20template%20combine%20to%20produce%20two%20spaces%20between%20the%20message%20and%20the%20hint%3A%0A%0A%60%60%60%0A%3F%20Do%20you%20want%20to%20use%20TypeScript%3F%20%28default%3A%20Yes%29%20%20%28Y%2Fn%29%0A%60%60%60%0A%0ABefore%20this%20PR%20the%20raw%20%60message%60%20%28no%20trailing%20space%29%20was%20used%20here%2C%20so%20only%20one%20space%20appeared.%20Consider%20trimming%20%60displayMessage%60%20at%20the%20point%20of%20use%20%E2%80%94%20the%20same%20%60renderedMessage%60%20alias%20used%20inside%20%60renderConfirmSelection%60%20would%20work%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%60%24%7Bchalk.green%28%22%3F%22%29%7D%20%24%7Bchalk.bold%28displayMessage.trimEnd%28%29%29%7D%20%24%7Bchalk.dim%28confirmHint%29%7D%20%60%2C%0A%60%60%60%0A%0A&repo=gaureshpai%2Fcreate-next-quick&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Flib%2Fprompts.js%3A54%0A**Double%20space%20before%20confirm%20hint**%0A%0A%60displayMessage%60%20is%20constructed%20with%20a%20trailing%20space%20on%20line%2035%20%28the%20template%20literal%20ends%20with%20%60%7D%20%22%60%29.%20When%20this%20is%20interpolated%20into%20the%20%60ask%60%20call%20with%20%60%60%20%60%24%7Bchalk.bold%28displayMessage%29%7D%20%24%7Bchalk.dim%28confirmHint%29%7D%20%60%20%60%60%2C%20the%20trailing%20space%20from%20%60displayMessage%60%20and%20the%20leading%20space%20from%20the%20template%20combine%20to%20produce%20two%20spaces%20between%20the%20message%20and%20the%20hint%3A%0A%0A%60%60%60%0A%3F%20Do%20you%20want%20to%20use%20TypeScript%3F%20%28default%3A%20Yes%29%20%20%28Y%2Fn%29%0A%60%60%60%0A%0ABefore%20this%20PR%20the%20raw%20%60message%60%20%28no%20trailing%20space%29%20was%20used%20here%2C%20so%20only%20one%20space%20appeared.%20Consider%20trimming%20%60displayMessage%60%20at%20the%20point%20of%20use%20%E2%80%94%20the%20same%20%60renderedMessage%60%20alias%20used%20inside%20%60renderConfirmSelection%60%20would%20work%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%60%24%7Bchalk.green%28%22%3F%22%29%7D%20%24%7Bchalk.bold%28displayMessage.trimEnd%28%29%29%7D%20%24%7Bchalk.dim%28confirmHint%29%7D%20%60%2C%0A%60%60%60%0A%0A&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/prompts.js
Line: 54

Comment:
**Double space before confirm hint**

`displayMessage` is constructed with a trailing space on line 35 (the template literal ends with `} "`). When this is interpolated into the `ask` call with `` `${chalk.bold(displayMessage)} ${chalk.dim(confirmHint)} ` ``, the trailing space from `displayMessage` and the leading space from the template combine to produce two spaces between the message and the hint:

```
? Do you want to use TypeScript? (default: Yes)  (Y/n)
```

Before this PR the raw `message` (no trailing space) was used here, so only one space appeared. Consider trimming `displayMessage` at the point of use — the same `renderedMessage` alias used inside `renderConfirmSelection` would work:

```suggestion
        `${chalk.green("?")} ${chalk.bold(displayMessage.trimEnd())} ${chalk.dim(confirmHint)} `,
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["Harden prompt test runner input"](https://github.com/gaureshpai/create-next-quick/commit/193f92c9188ad28089e8b378a2c8db00fe66ee30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28998266)</sub>

<!-- /greptile_comment -->