### PR TITLE
feat: show help for unknown flags and add showHelp function

### DIFF
--- a/src/create-next-quick.js
+++ b/src/create-next-quick.js
@@ -57,7 +57,8 @@ const appName = args.find((arg) => !arg.startsWith("-"));
 const knownFlags = ["-h", "--help", "-v", "--version", "-i", "--interactive"];
 const unknownFlags = args.filter((arg) => arg.startsWith("-") && !knownFlags.includes(arg));
 if (unknownFlags.length > 0) {
-  showHelp();
+  console.error(chalk.red.bold(`Error: Unknown flag(s): ${unknownFlags.join(", ")}`));
+  showHelp(1);
 }
 
 if (isInteractiveMode && appName) {

--- a/src/create-next-quick.js
+++ b/src/create-next-quick.js
@@ -58,7 +58,7 @@ const knownFlags = ["-h", "--help", "-v", "--version", "-i", "--interactive"];
 const unknownFlags = args.filter((arg) => arg.startsWith("-") && !knownFlags.includes(arg));
 if (unknownFlags.length > 0) {
   console.error(chalk.red.bold(`Error: Unknown flag(s): ${unknownFlags.join(", ")}`));
-  showHelp();
+  showHelp(console.error);
   process.exit(1);
 }
 

--- a/src/create-next-quick.js
+++ b/src/create-next-quick.js
@@ -26,8 +26,8 @@ if (parseInt(currentNodeVersion.split(".")[0], 10) < MIN_NODE_VERSION) {
 
 const args = process.argv.slice(2);
 
-const showHelp = () => {
-  console.log(`
+const showHelp = (log = console.log) => {
+  log(`
 Usage: create-next-quick [project-name] [options]
 
 Options:

--- a/src/create-next-quick.js
+++ b/src/create-next-quick.js
@@ -39,11 +39,11 @@ Examples:
   npx create-next-quick my-app          # Create a new project
   cd my-existing-app && npx create-next-quick -i  # Integrate into existing project
 `);
-  process.exit(0);
 };
 
 if (args.includes("-h") || args.includes("--help")) {
   showHelp();
+  process.exit(0);
 }
 
 if (args.includes("-v") || args.includes("--version")) {
@@ -57,7 +57,9 @@ const appName = args.find((arg) => !arg.startsWith("-"));
 const knownFlags = ["-h", "--help", "-v", "--version", "-i", "--interactive"];
 const unknownFlags = args.filter((arg) => arg.startsWith("-") && !knownFlags.includes(arg));
 if (unknownFlags.length > 0) {
+  console.error(chalk.red.bold(`Error: Unknown flag(s): ${unknownFlags.join(", ")}`));
   showHelp();
+  process.exit(1);
 }
 
 if (isInteractiveMode && appName) {

--- a/src/create-next-quick.js
+++ b/src/create-next-quick.js
@@ -26,7 +26,7 @@ if (parseInt(currentNodeVersion.split(".")[0], 10) < MIN_NODE_VERSION) {
 
 const args = process.argv.slice(2);
 
-if (args.includes("-h") || args.includes("--help")) {
+const showHelp = () => {
   console.log(`
 Usage: create-next-quick [project-name] [options]
 
@@ -40,6 +40,10 @@ Examples:
   cd my-existing-app && npx create-next-quick -i  # Integrate into existing project
 `);
   process.exit(0);
+};
+
+if (args.includes("-h") || args.includes("--help")) {
+  showHelp();
 }
 
 if (args.includes("-v") || args.includes("--version")) {
@@ -49,6 +53,12 @@ if (args.includes("-v") || args.includes("--version")) {
 
 const isInteractiveMode = args.includes("-i") || args.includes("--interactive");
 const appName = args.find((arg) => !arg.startsWith("-"));
+
+const knownFlags = ["-h", "--help", "-v", "--version", "-i", "--interactive"];
+const unknownFlags = args.filter((arg) => arg.startsWith("-") && !knownFlags.includes(arg));
+if (unknownFlags.length > 0) {
+  showHelp();
+}
 
 if (isInteractiveMode && appName) {
   console.error(


### PR DESCRIPTION
- Extract help message into reusable showHelp() function
- Show help when unknown flags are provided instead of treating them as paths
- Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line argument validation. The CLI now properly recognizes supported flags and displays usage information when invalid arguments are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is small, well-scoped, and the previously raised exit-code concern has been correctly resolved.

The PR makes a single-file change that correctly fixes the known issue. The exit code for unknown flags is now 1 (not 0), showHelp() is properly reused for the --help path, and no existing behaviour is broken. The only remaining note is a minor stdout/stderr mixing convention, which does not affect correctness.

No files require special attention.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22gaureshpai%2Fcreate-next-quick%22%20on%20the%20existing%20branch%20%22fix%2Fhelp-for-unknown-flags%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhelp-for-unknown-flags%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcreate-next-quick.js%3A59-63%0A**Help%20text%20written%20to%20stdout%20on%20error%20path**%0A%0AWhen%20%60showHelp%28%29%60%20is%20called%20from%20the%20unknown-flags%20error%20path%2C%20the%20usage%20information%20is%20printed%20to%20%60stdout%60%20%28via%20%60console.log%60%29%20while%20the%20preceding%20error%20message%20is%20printed%20to%20%60stderr%60%20%28via%20%60console.error%60%29.%20Mixing%20streams%20for%20a%20single%20logical%20error%20response%20can%20cause%20output%20ordering%20issues%20when%20the%20caller%20redirects%20one%20stream%2C%20and%20it%20deviates%20from%20the%20convention%20that%20all%20output%20for%20an%20error%20condition%20belongs%20on%20%60stderr%60.%0A%0AA%20lightweight%20fix%20is%20to%20pass%20a%20%60stream%60%20argument%20%28defaulting%20to%20%60process.stdout%60%20for%20the%20%60--help%60%20path%29%20or%20just%20inline%20%60process.stderr.write%60%20for%20the%20error%20case%3A%0A%0A%60%60%60js%0Aconst%20showHelp%20%3D%20%28out%20%3D%20process.stdout%29%20%3D%3E%20%7B%0A%20%20out.write%28%60%0AUsage%3A%20create-next-quick%20%5Bproject-name%5D%20%5Boptions%5D%0A...%0A%60%29%3B%0A%7D%3B%0A%0A%2F%2F%20--help%20path%0AshowHelp%28%29%3B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20prints%20to%20stdout%0A%0A%2F%2F%20unknown%20flags%20path%0AshowHelp%28process.stderr%29%3B%20%20%20%20%2F%2F%20prints%20to%20stderr%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcreate-next-quick.js%3A59-63%0A**Help%20text%20written%20to%20stdout%20on%20error%20path**%0A%0AWhen%20%60showHelp%28%29%60%20is%20called%20from%20the%20unknown-flags%20error%20path%2C%20the%20usage%20information%20is%20printed%20to%20%60stdout%60%20%28via%20%60console.log%60%29%20while%20the%20preceding%20error%20message%20is%20printed%20to%20%60stderr%60%20%28via%20%60console.error%60%29.%20Mixing%20streams%20for%20a%20single%20logical%20error%20response%20can%20cause%20output%20ordering%20issues%20when%20the%20caller%20redirects%20one%20stream%2C%20and%20it%20deviates%20from%20the%20convention%20that%20all%20output%20for%20an%20error%20condition%20belongs%20on%20%60stderr%60.%0A%0AA%20lightweight%20fix%20is%20to%20pass%20a%20%60stream%60%20argument%20%28defaulting%20to%20%60process.stdout%60%20for%20the%20%60--help%60%20path%29%20or%20just%20inline%20%60process.stderr.write%60%20for%20the%20error%20case%3A%0A%0A%60%60%60js%0Aconst%20showHelp%20%3D%20%28out%20%3D%20process.stdout%29%20%3D%3E%20%7B%0A%20%20out.write%28%60%0AUsage%3A%20create-next-quick%20%5Bproject-name%5D%20%5Boptions%5D%0A...%0A%60%29%3B%0A%7D%3B%0A%0A%2F%2F%20--help%20path%0AshowHelp%28%29%3B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20prints%20to%20stdout%0A%0A%2F%2F%20unknown%20flags%20path%0AshowHelp%28process.stderr%29%3B%20%20%20%20%2F%2F%20prints%20to%20stderr%0A%60%60%60%0A%0A&repo=gaureshpai%2Fcreate-next-quick&pr=79&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcreate-next-quick.js%3A59-63%0A**Help%20text%20written%20to%20stdout%20on%20error%20path**%0A%0AWhen%20%60showHelp%28%29%60%20is%20called%20from%20the%20unknown-flags%20error%20path%2C%20the%20usage%20information%20is%20printed%20to%20%60stdout%60%20%28via%20%60console.log%60%29%20while%20the%20preceding%20error%20message%20is%20printed%20to%20%60stderr%60%20%28via%20%60console.error%60%29.%20Mixing%20streams%20for%20a%20single%20logical%20error%20response%20can%20cause%20output%20ordering%20issues%20when%20the%20caller%20redirects%20one%20stream%2C%20and%20it%20deviates%20from%20the%20convention%20that%20all%20output%20for%20an%20error%20condition%20belongs%20on%20%60stderr%60.%0A%0AA%20lightweight%20fix%20is%20to%20pass%20a%20%60stream%60%20argument%20%28defaulting%20to%20%60process.stdout%60%20for%20the%20%60--help%60%20path%29%20or%20just%20inline%20%60process.stderr.write%60%20for%20the%20error%20case%3A%0A%0A%60%60%60js%0Aconst%20showHelp%20%3D%20%28out%20%3D%20process.stdout%29%20%3D%3E%20%7B%0A%20%20out.write%28%60%0AUsage%3A%20create-next-quick%20%5Bproject-name%5D%20%5Boptions%5D%0A...%0A%60%29%3B%0A%7D%3B%0A%0A%2F%2F%20--help%20path%0AshowHelp%28%29%3B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20prints%20to%20stdout%0A%0A%2F%2F%20unknown%20flags%20path%0AshowHelp%28process.stderr%29%3B%20%20%20%20%2F%2F%20prints%20to%20stderr%0A%60%60%60%0A%0A&pr=79&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/create-next-quick.js
Line: 59-63

Comment:
**Help text written to stdout on error path**

When `showHelp()` is called from the unknown-flags error path, the usage information is printed to `stdout` (via `console.log`) while the preceding error message is printed to `stderr` (via `console.error`). Mixing streams for a single logical error response can cause output ordering issues when the caller redirects one stream, and it deviates from the convention that all output for an error condition belongs on `stderr`.

A lightweight fix is to pass a `stream` argument (defaulting to `process.stdout` for the `--help` path) or just inline `process.stderr.write` for the error case:

```js
const showHelp = (out = process.stdout) => {
  out.write(`
Usage: create-next-quick [project-name] [options]
...
`);
};

// --help path
showHelp();                  // prints to stdout

// unknown flags path
showHelp(process.stderr);    // prints to stderr
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;fix/help-for-unknown-flags..."](https://github.com/gaureshpai/create-next-quick/commit/d76146edf504c56d9475f929fd8b18e55d94bdc5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29424956)</sub>

<!-- /greptile_comment -->